### PR TITLE
Inherited presenters do not inherit subjects

### DIFF
--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -96,4 +96,12 @@ describe SimplePresenter::Base do
       subject.instance_variable_get("@subject").should == user
     end
   end
+
+  describe "inherited presenter" do
+    it "inherits subjects" do
+      user = User.new
+      presenter = GamerPresenter.new(user)
+      presenter.person.should == user
+    end
+  end
 end

--- a/spec/support/inherited_presenter.rb
+++ b/spec/support/inherited_presenter.rb
@@ -1,0 +1,7 @@
+class PersonPresenter < SimplePresenter::Base
+  subject :person
+  attr_reader :person
+end
+
+class GamerPresenter < PersonPresenter
+end


### PR DESCRIPTION
I've included a test describing the issue. Is this an intended behavior?
